### PR TITLE
Bugfix PHP 7.4 deprecated syntax

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -1082,7 +1082,7 @@ class Message extends BaseMessage
     public function setGlobalMergeVars(array $mergeVars)
     {
         foreach ($mergeVars as $name => $content) {
-            if ($name{0} === '_') {
+            if ($name[0] === '_') {
                 continue;
             }
 


### PR DESCRIPTION
Se soluciona bug que arrojaba error: [Array and string offset access syntax with curly braces is deprecated](https://wiki.php.net/rfc/deprecate_curly_braces_array_access)